### PR TITLE
Fix storage setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,8 @@ services:
     ports:
       - '8888:8888'
     volumes:
-      - './media/:/mnt/media'
+      - './media/media1:/srv/media1'
+      - './media/thumbnail:/srv/thumbnail'
     logging:
       driver: "none"
 
@@ -105,7 +106,8 @@ services:
       - vidispinesolr
       - postgres
     volumes:
-      - './media/:/mnt/media'
+      - './media/media1:/srv/media1'
+      - './media/thumbnail:/srv/thumbnail'
     mac_address: 00:0c:29:8f:ab:2a
     logging:
       driver: "none"

--- a/setup/quickstart/quickstart.sh
+++ b/setup/quickstart/quickstart.sh
@@ -18,10 +18,8 @@ if [ ${CURRENT_SETUP_VERSION} -eq 0 ]; then
   echo "Running Step ${CURRENT_SETUP_VERSION}"
   vidispine-api -X POST -b APIinit -a text/plain /
   vidispine-api -X POST -f /quickstart/resource_transcoder.json resource/transcoder
-  vidispine-api -X POST -f /quickstart/resource_thumbnail.json resource/thumbnail
   vidispine-api -X PUT -f /quickstart/configuration_properties_solrpath.json configuration/properties
   vidispine-api -X PUT -f /quickstart/configuration_properties_portal_uri.json configuration/properties
-  vidispine-api -X POST -f /quickstart/storage.json storage
   echo "Complete Step ${CURRENT_SETUP_VERSION}"
   CURRENT_SETUP_VERSION=$((${CURRENT_SETUP_VERSION} + 1))
   vidispine-api -X PUT -c text/plain -d ${CURRENT_SETUP_VERSION} configuration/properties/nmrsetup


### PR DESCRIPTION
Setup container currently creates a new storage, and repoints thumbnails directory to `/mnt/media` and `/mnt/media/thumbnail/`

This duplicates what is already put in place by Cantemo's own setup process, and in the case of the storage, creates a duplicate in a broken state.

This PR removes both of those scripted steps, leaving Cantemo's default.

If additional storages are needed for demo purposes we can still make use of the setup scripts.